### PR TITLE
Remove unecessary sorts, add undefined check to packageJson sort

### DIFF
--- a/packages/cli/src/lib/commands/workspace-lint.ts
+++ b/packages/cli/src/lib/commands/workspace-lint.ts
@@ -17,46 +17,14 @@ function sortItems(items: Record<string, unknown> = {}) {
     .reduce((acc, curr) => ({ ...acc, [curr]: items[curr] }), {})
 }
 
-export function sortTsConfigPaths(file) {
-  return {
-    ...file,
-    compilerOptions: {
-      ...file?.compilerOptions,
-      paths: sortItems(file?.compilerOptions?.paths),
-    },
-  }
-}
-
-export function sortWorkspaceProjects(file) {
-  return {
-    ...file,
-    projects: sortItems(file?.projects),
-  }
-}
-
 export function sortPackageJson(file) {
   return {
     ...file,
-    scripts: sortItems(file?.scripts),
+    ...(file?.scripts ? { scripts: sortItems(file?.scripts) } : {}),
   }
 }
 
 export async function workspaceLint({ dryRun, skipPackageJson }: { dryRun: boolean; skipPackageJson: boolean }) {
-  for (const file of projectFiles) {
-    const contents = await getFileContents(file)
-    if (contents && !dryRun) {
-      await writeJson(file, sortWorkspaceProjects(contents), { spaces: 2 })
-      execSync('prettier --write ' + file)
-    }
-  }
-
-  for (const file of tsconfigFiles) {
-    const contents = await getFileContents(file)
-    if (contents && !dryRun) {
-      await writeJson(file, sortTsConfigPaths(contents), { spaces: 2 })
-      execSync('prettier --write ' + file)
-    }
-  }
   if (!skipPackageJson) {
     const file = 'package.json'
     const contents = await getFileContents(file)


### PR DESCRIPTION
Nx 13+ already handles sorting the TsConfig paths and Workspace projects so I've removed them from the command so this now only sorts the package.json `scripts` property now.

Added an undefined check to the sort function so that it doesn't add the property if it doesn't exist. Should never happen since package.json should always have the `scripts` property.

Fixes:
#152 